### PR TITLE
feat: introduce exclude option for ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ This is a list of point of presence to include.
 
 This is a list of point of presence to exclude as checkpoints.
 
+### `uptrends.ionos-cloud.github.io/monitor.exclude-from-monitoring: ""`
+
+This excludes an ingress from monitoring
+
 ## Examples
 
 [/examples](/examples/) contains the example of an `Ingress` and `Uptrends` based monitor.


### PR DESCRIPTION
As a user, I want to exclude an ingress from being monitored for the following reasons:
- URL not correct
- Returns 401 or similar
- not important to monitor

This adds the possibility to configure an annotation on the ingress `uptrends.ionos-cloud.github.io/monitor.exclude-from-monitoring: ""` to make this happen